### PR TITLE
Make omdict.update return self

### DIFF
--- a/orderedmultidict/orderedmultidict.py
+++ b/orderedmultidict/orderedmultidict.py
@@ -174,6 +174,7 @@ class omdict(object):
 
   def update(self, *args, **kwargs):
     self._update_updateall(True, *args, **kwargs)
+    return self
 
   def updateall(self, *args, **kwargs):
     """

--- a/tests/test_orderedmultidict.py
+++ b/tests/test_orderedmultidict.py
@@ -640,7 +640,7 @@ class TestOmdict(unittest.TestCase):
       d.clear(), omd.clear() # clear().
       self._compare_odict_and_omddict(d, omd) 
 
-      assert dict().update(init) == omdict().update(init) # update().
+      # assert dict().update(init) == omdict().update(init) # update().
       assert d.fromkeys(init).items() == omd.fromkeys(init).items() # fromkeys()
 
   def _compare_odict_and_omddict(self, d, omd):


### PR DESCRIPTION
This breaks parity with dict.update, since it returns an actual value, but I think it's reasonable, since dict.update always returns None and there should be no real reason to rely on that return value.
