### PR TITLE
Add (basic) type information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ build/
 *.pyo
 *.egg
 *.egg-info
+.mypy_cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ matrix:
 
     - python: 2.6
       env: TOXENV=py26
+      dist: trusty
     - python: 2.7
       env: TOXENV=py27
     - python: 3.4

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,7 @@
+[mypy]
+check_untyped_defs = True
+no_implicit_optional = True
+[mypy-setup]
+ignore_errors = True
+[mypy-ordereddict]
+ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -3,5 +3,3 @@ check_untyped_defs = True
 no_implicit_optional = True
 [mypy-setup]
 ignore_errors = True
-[mypy-ordereddict]
-ignore_missing_imports = True

--- a/orderedmultidict/__init__.py
+++ b/orderedmultidict/__init__.py
@@ -12,10 +12,12 @@
 
 from os.path import dirname, join as pjoin
 
+from typing import Dict
+
 from .orderedmultidict import *  # noqa
 
 # Import all variables in __version__.py without explicit imports.
-meta = {}
+meta = {}  # type: Dict
 with open(pjoin(dirname(__file__), '__version__.py')) as f:
     exec(f.read(), meta)
 globals().update(dict((k, v) for k, v in meta.items() if k not in globals()))

--- a/orderedmultidict/__init__.py
+++ b/orderedmultidict/__init__.py
@@ -10,9 +10,11 @@
 # License: Build Amazing Things (Unlicense)
 #
 
+import sys
 from os.path import dirname, join as pjoin
 
-from typing import Dict
+if sys.version_info > (2, 6):
+    from typing import Dict
 
 from .orderedmultidict import *  # noqa
 

--- a/orderedmultidict/__init__.py
+++ b/orderedmultidict/__init__.py
@@ -13,7 +13,8 @@
 import sys
 from os.path import dirname, join as pjoin
 
-if sys.version_info >= (2, 7):
+# There's no typing module until 3.5
+if sys.version_info >= (3, 5):
     from typing import Dict
 
 from .orderedmultidict import *  # noqa

--- a/orderedmultidict/__init__.py
+++ b/orderedmultidict/__init__.py
@@ -13,7 +13,7 @@
 import sys
 from os.path import dirname, join as pjoin
 
-if sys.version_info > (2, 6):
+if sys.version_info >= (2, 7):
     from typing import Dict
 
 from .orderedmultidict import *  # noqa

--- a/orderedmultidict/orderedmultidict.py
+++ b/orderedmultidict/orderedmultidict.py
@@ -20,7 +20,8 @@ from six.moves import map, zip_longest
 
 from .itemlist import itemlist
 
-if sys.version_info >= (2, 7):
+# There's no typing module in 2.x
+if sys.version_info >= (3, 4):
     from typing import Iterable, Tuple, Any, List, Dict
 
 if six.PY2:

--- a/orderedmultidict/orderedmultidict.py
+++ b/orderedmultidict/orderedmultidict.py
@@ -15,11 +15,13 @@ from __future__ import absolute_import
 import sys
 from itertools import chain
 
-from typing import Iterable, Tuple, Any, List, Dict
 import six
 from six.moves import map, zip_longest
 
 from .itemlist import itemlist
+
+if sys.version_info > (2, 6):
+    from typing import Iterable, Tuple, Any, List, Dict
 
 if six.PY2:
     from collections import MutableMapping

--- a/orderedmultidict/orderedmultidict.py
+++ b/orderedmultidict/orderedmultidict.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import
 import sys
 from itertools import chain
 
+from typing import Iterable, Tuple, Any, List, Dict
 import six
 from six.moves import map, zip_longest
 
@@ -25,9 +26,11 @@ if six.PY2:
 else:
     from collections.abc import MutableMapping
 try:
-    from collections import OrderedDict as odict  # Python 2.7 and later.
+    # Python 2.7 and later.
+    from collections import OrderedDict as odict  # type: ignore
 except ImportError:
-    from ordereddict import OrderedDict as odict  # Python 2.6 and earlier.
+    # Python 2.6 and earlier.
+    from ordereddict import OrderedDict as odict  # type: ignore
 
 
 _absent = object()  # Marker that means no parameter was provided.
@@ -223,7 +226,7 @@ class omdict(MutableMapping):
         # <leftovers>. Items in <replacements> are new values to replace old
         # values for a given key, and items in <leftovers> are new items to be
         # added.
-        replacements, leftovers = dict(), []
+        replacements, leftovers = dict(), []  # type: Tuple[Dict, List]
         for mapping in chain(args, [kwargs]):
             self._bin_update_items(
                 self._items_iterator(mapping), replace_at_most_one,
@@ -626,7 +629,9 @@ class omdict(MutableMapping):
         """
         if key is not _absent:
             if key in self:
-                items = [(node.key, node.value) for node in self._map[key]]
+                items = [
+                    (node.key, node.value) for node in self._map[key]
+                ]  # type: Iterable[Tuple[Any, Any]]
                 return iter(items)
             raise KeyError(key)
         items = six.iteritems(self._map)

--- a/orderedmultidict/orderedmultidict.py
+++ b/orderedmultidict/orderedmultidict.py
@@ -20,7 +20,7 @@ from six.moves import map, zip_longest
 
 from .itemlist import itemlist
 
-if sys.version_info > (2, 6):
+if sys.version_info >= (2, 7):
     from typing import Iterable, Tuple, Any, List, Dict
 
 if six.PY2:

--- a/orderedmultidict/orderedmultidict.py
+++ b/orderedmultidict/orderedmultidict.py
@@ -20,8 +20,8 @@ from six.moves import map, zip_longest
 
 from .itemlist import itemlist
 
-# There's no typing module in 2.x
-if sys.version_info >= (3, 4):
+# There's no typing module until 3.5
+if sys.version_info >= (3, 5):
     from typing import Iterable, Tuple, Any, List, Dict
 
 if six.PY2:

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ omdict retains method parity with dict.
 
 Information and documentation at https://github.com/gruns/orderedmultidict.''')
 
-required = ['six>=1.8.0']
+required = ['six>=1.8.0', "typing"]
 if sys.version_info < (2, 7):
     required.append('ordereddict')
 
@@ -93,6 +93,9 @@ setup(
     long_description=long_description,
     packages=find_packages(),
     include_package_data=True,
+    package_data={
+        "orderedmultidict": ["py.typed"],
+    },
     platforms=['any'],
     classifiers=[
         'Topic :: Software Development :: Libraries',

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ omdict retains method parity with dict.
 
 Information and documentation at https://github.com/gruns/orderedmultidict.''')
 
-required = ['six>=1.8.0', "typing"]
+required = ['six>=1.8.0']
 if sys.version_info < (2, 7):
     required.append('ordereddict')
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,5 +11,9 @@ deps =
   unittest2
 
 [testenv:codestyle]
-deps = flake8
-commands = flake8
+deps =
+     flake8
+     mypy
+commands =
+         mypy .
+         flake8


### PR DESCRIPTION
Hi!  This PR adds very basic type information to this library.  This adds one new runtime dependency (typing, to continue support for 2.x) and one new development dependency: mypy.

My motive for doing this is to get type information added to furl which would help me in a private project.